### PR TITLE
updated info on chmod for data_pgadmin

### DIFF
--- a/week_1_basics_n_setup/2_docker_sql/README.md
+++ b/week_1_basics_n_setup/2_docker_sql/README.md
@@ -202,7 +202,13 @@ Shutting it down:
 docker-compose down
 ```
 
-Note: to make pgAdmin configuration persistent, mount a volume to the `/var/lib/pgadmin` folder:
+Note: to make pgAdmin configuration persistent, create a folder `data_pgadmin`. Change its permission via
+
+```bash
+sudo chown 5050:5050 data_pgadmin
+```
+
+and mount it to the `/var/lib/pgadmin` folder:
 
 ```yaml
 services:


### PR DESCRIPTION
Docker cannot write to the `data_pgadmin` folder. We need to change the permission to make the volume mount work.