### PR TITLE
fix wildcard in GCSToGCSOperator

### DIFF
--- a/week_3_data_warehouse/airflow/dags/gcs_to_bq_dag.py
+++ b/week_3_data_warehouse/airflow/dags/gcs_to_bq_dag.py
@@ -40,7 +40,7 @@ with DAG(
             source_bucket=BUCKET,
             source_object=f'{INPUT_PART}/{colour}_{DATASET}*.{INPUT_FILETYPE}',
             destination_bucket=BUCKET,
-            destination_object=f'{colour}/{colour}_{DATASET}*.{INPUT_FILETYPE}',
+            destination_object=f'{colour}/{colour}_{DATASET}',
             move_object=True
         )
 


### PR DESCRIPTION
The `GCSToGCSOperator` in the dag is renaming files not optimally.

Example:
`/raw/yellow_tripdata_2019-04.parquet` is moved to `/yellow/yellow_tripdata*.parquet_2019-04.parquet`
The wildcard is included into the name of the moved file.

According to the airflow documentation of the [`GCSToGCSOperator`](https://airflow.apache.org/docs/apache-airflow-providers-google/stable/operators/transfer/gcs_to_gcs.html#copy-multiple-files) there is no need to specify the wildcard in the `destination_object` parameter. The wildcard * is treated as character and included into the destination file name as seen in the example above.

Everything, which is left of the wildcard in the `source_object` parameter is omitted in the destination file name (e.g. yellow_tripdata). To keep this part of the file name, this part has to be added to the `destination_object` parameter. 

After the fix in the code, the file names will be as followed:
`/raw/yellow_tripdata_2019-04.parquet` is moved to `/yellow/yellow_tripdata_2019-04.parquet`
