### PR TITLE
fix start_date bug in week 2 homework

### DIFF
--- a/week_2_data_ingestion/homework/solution.py
+++ b/week_2_data_ingestion/homework/solution.py
@@ -36,7 +36,7 @@ def upload_to_gcs(bucket, object_name, local_file):
 
 default_args = {
     "owner": "airflow",
-    "start_date": days_ago(1),
+    #"start_date": days_ago(1),
     "depends_on_past": False,
     "retries": 1,
 }


### PR DESCRIPTION
"start_date": days_ago(1) in default_args seems to override the start_date set in the individual dags. When I removed start_date from default_args, the dags ran correctly in the airflow UI without having to run backfill from the command line like Alexey had to do in the homework solution video.