### PR TITLE
Homework Week 4 - Fixed typos

### DIFF
--- a/week_4_analytics_engineering/homework.md
+++ b/week_4_analytics_engineering/homework.md
@@ -33,7 +33,7 @@ Run it via the CLI without limits (is_test_run: false).
 ### Question 4: 
 **What is the count of records in the model fact_fhv_trips after running all dependencies with the test run variable disabled (:false)**  
 Create a core model for the stg_fhv_tripdata joining with dim_zones.
-Similar to what we've done in fact_trips, keep only records with knwon pickup and doproff locations entries for pickup and dropoff locations. 
+Similar to what we've done in fact_trips, keep only records with known pickup and dropoff locations entries for pickup and dropoff locations. 
 Run it via the CLI without limits (is_test_run: false).
 
 ### Question 5: 


### PR DESCRIPTION
In addition to the typos, I would like to ask to specify question 2, 3 and 5 in greater detail:

- **Question 2: filtering by year 2019 and 2020.**   
It's meant to be pickup datetime, as in question 1, right?
- **Question 3: keeping only records with entries for affiliated_base_number**  
FHV Trips has a field dispatching_base_num, but not affiliated_base_number (see [NYC Data Dictionary](https://www1.nyc.gov/assets/tlc/downloads/pdf/data_dictionary_trip_records_fhv.pdf)). Is dispatching_base_num the field wanted?
- **Question 5: month with the biggest amount of rides**  
It's meant to be based on pickup datetime, as in question 1, right?