### PR TITLE
Remove `cask` for `brew cask install java`.

### DIFF
--- a/week_5_batch_processing/setup/macos.md
+++ b/week_5_batch_processing/setup/macos.md
@@ -12,7 +12,7 @@ Ensure Brew and Java installed in your system:
 ```bash
 xcode-select –install
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-brew cask install java
+brew install java
 ```
 
 


### PR DESCRIPTION
I believe using `brew cask` here is incorrect (at least for me it didn't work)
1. `cask` has been deprecated since version `2.6.0` (see [changelog](https://brew.sh/2020/12/01/homebrew-2.6.0/))
2. `brew install --cask java` does not work either (no cask `java`), but `brew install java` does work