### PR TITLE
Add `pip install pyspark`

### DIFF
--- a/week_5_batch_processing/setup/pyspark.md
+++ b/week_5_batch_processing/setup/pyspark.md
@@ -1,7 +1,12 @@
-
 ## PySpark
 
 This document assumes you already have python.
+
+Install PySpark (see [docs](https://spark.apache.org/docs/latest/api/python/getting_started/install.html))
+
+```sh
+pip install pyspark
+```
 
 To run PySpark, we first need to add it to `PYTHONPATH`:
 


### PR DESCRIPTION
Not sure but I believe this a required step...
(I supposed `conda` could be used instead of `pip` as well)