### PR TITLE
Updated week 6 requirents.txt to specify kafka-python version number

### DIFF
--- a/week_6_stream_processing/requirements.txt
+++ b/week_6_stream_processing/requirements.txt
@@ -1,4 +1,4 @@
-kafka-python
+kafka-python==1.4.6
 confluent_kafka
 requests
 avro


### PR DESCRIPTION
Seems like a lot of students are running into an error running the stream consumer in week 6. Specifying this version number in the requirements.txt should resolve the issue.