### PR TITLE
modified README and ingest python script to read from parquet file

### DIFF
--- a/week_1_basics_n_setup/2_docker_sql/Dockerfile
+++ b/week_1_basics_n_setup/2_docker_sql/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9.1
 
 RUN apt-get install wget
-RUN pip install pandas sqlalchemy psycopg2
+RUN pip install pandas sqlalchemy psycopg2 pyarrow
 
 WORKDIR /app
 COPY ingest_data.py ingest_data.py 

--- a/week_1_basics_n_setup/2_docker_sql/README.md
+++ b/week_1_basics_n_setup/2_docker_sql/README.md
@@ -98,6 +98,16 @@ Dataset:
 
 * https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page
 * https://www1.nyc.gov/assets/tlc/downloads/pdf/data_dictionary_trip_records_yellow.pdf
+---
+>### 2022 Updates:
+>
+>According to the [TLC data website](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page), from 05/13/2022, the data will be in ```.parquet``` format instead of ```.csv```
+>
+>The website has provided a useful [link](https://www1.nyc.gov/assets/tlc/downloads/pdf/working_parquet_format.pdf) with sample steps to read ```.parquet``` file and convert it to Pandas data frame.
+>
+> ```ingest_data.py``` python script has been updated with the functions required to read ```.parquet``` file
+
+---
 
 
 ### pgAdmin

--- a/week_1_basics_n_setup/2_docker_sql/ingest_data.py
+++ b/week_1_basics_n_setup/2_docker_sql/ingest_data.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-import os
 import argparse
-
-from time import time
-
+import os
+import pyarrow.parquet as pq
 import pandas as pd
 from sqlalchemy import create_engine
 
@@ -18,46 +16,20 @@ def main(params):
     db = params.db
     table_name = params.table_name
     url = params.url
-    csv_name = 'output.csv'
-
-    os.system(f"wget {url} -O {csv_name}")
+    filename = 'output.parquet'
+    
+    os.system(f"wget {url} -O {filename}")
 
     engine = create_engine(f'postgresql://{user}:{password}@{host}:{port}/{db}')
+    
+    parquet_table = pq.read_table(filename)
+    df = parquet_table.to_pandas()
 
-    df_iter = pd.read_csv(csv_name, iterator=True, chunksize=100000)
+    df.to_sql(name="yellow_taxi_data", con=engine, if_exists='append', chunksize=100000)
 
-    df = next(df_iter)
-
-    df.tpep_pickup_datetime = pd.to_datetime(df.tpep_pickup_datetime)
-    df.tpep_dropoff_datetime = pd.to_datetime(df.tpep_dropoff_datetime)
-
-    df.head(n=0).to_sql(name=table_name, con=engine, if_exists='replace')
-
-    df.to_sql(name=table_name, con=engine, if_exists='append')
-
-
-    while True: 
-
-        try:
-            t_start = time()
-            
-            df = next(df_iter)
-
-            df.tpep_pickup_datetime = pd.to_datetime(df.tpep_pickup_datetime)
-            df.tpep_dropoff_datetime = pd.to_datetime(df.tpep_dropoff_datetime)
-
-            df.to_sql(name=table_name, con=engine, if_exists='append')
-
-            t_end = time()
-
-            print('inserted another chunk, took %.3f second' % (t_end - t_start))
-
-        except StopIteration:
-            print("Finished ingesting data into the postgres database")
-            break
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Ingest CSV data to Postgres')
+    parser = argparse.ArgumentParser(description='Ingest data to Postgres')
 
     parser.add_argument('--user', required=True, help='user name for postgres')
     parser.add_argument('--password', required=True, help='password for postgres')
@@ -65,7 +37,7 @@ if __name__ == '__main__':
     parser.add_argument('--port', required=True, help='port for postgres')
     parser.add_argument('--db', required=True, help='database name for postgres')
     parser.add_argument('--table_name', required=True, help='name of the table where we will write the results to')
-    parser.add_argument('--url', required=True, help='url of the csv file')
+    parser.add_argument('--url', required=True, help='url of the parquet file')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
According to the [TLC data website](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page), from 05/13/2022, the data will be in parquet file format instead of csv file format. So updated the README file in week1 2_docker_sql folder and also updated the ingest_data.py to include the code to read from parquet file.