### PR TITLE
Updated spark version for Linux install

### DIFF
--- a/week_5_batch_processing/setup/linux.md
+++ b/week_5_batch_processing/setup/linux.md
@@ -1,7 +1,7 @@
 
 ## Linux
 
-Here we'll show you how to install Spark 3.0.3 for Linux.
+Here we'll show you how to install Spark 3.3.0 for Linux.
 We tested it on Ubuntu 20.04 (also WSL), but it should work
 for other Linux distros as well
 
@@ -53,28 +53,28 @@ rm openjdk-11.0.2_linux-x64_bin.tar.gz
 
 ### Installing Spark
 
-Download Spark. Use 3.0.3 version:
+Download Spark. Use 3.3.0 version:
 
 ```bash
-wget https://dlcdn.apache.org/spark/spark-3.0.3/spark-3.0.3-bin-hadoop3.2.tgz
+wget https://dlcdn.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz
 ```
 
 Unpack:
 
 ```bash
-tar xzfv spark-3.0.3-bin-hadoop3.2.tgz
+tar xzfv spark-3.3.0-bin-hadoop3.tgz
 ```
 
 Remove the archive:
 
 ```bash
-rm spark-3.0.3-bin-hadoop3.2.tgz
+rm spark-3.3.0-bin-hadoop3.tgz
 ```
 
 Add it to `PATH`:
 
 ```bash
-export SPARK_HOME="${HOME}/spark/spark-3.0.3-bin-hadoop3.2"
+export SPARK_HOME="${HOME}/spark/spark-3.3.0-bin-hadoop3"
 export PATH="${SPARK_HOME}/bin:${PATH}"
 ```
 


### PR DESCRIPTION
The original spark version and link are no longer available. Updated the Linux install instructions to reflect the latest spark version. 