### PR TITLE
Updated Spark Version in Linux Instructions

### DIFF
--- a/week_5_batch_processing/setup/linux.md
+++ b/week_5_batch_processing/setup/linux.md
@@ -1,7 +1,7 @@
 
 ## Linux
 
-Here we'll show you how to install Spark 3.3.0 for Linux.
+Here we'll show you how to install Spark 3.3.1 for Linux.
 We tested it on Ubuntu 20.04 (also WSL), but it should work
 for other Linux distros as well
 
@@ -56,7 +56,7 @@ rm openjdk-11.0.2_linux-x64_bin.tar.gz
 Download Spark. Use 3.3.0 version:
 
 ```bash
-wget https://dlcdn.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz
+wget https://dlcdn.apache.org/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz
 ```
 
 Unpack:


### PR DESCRIPTION
The instructions reference Spark 3.3.0 for the Linux Setup. This pull request updates the version to 3.3.1 and the link to the cdn to download Spark was updated. 