### PR TITLE
Modify docker-compose down command in README

### DIFF
--- a/week_1_basics_n_setup/2_docker_sql/README.md
+++ b/week_1_basics_n_setup/2_docker_sql/README.md
@@ -233,7 +233,7 @@ docker-compose up -d
 Shutting it down:
 
 ```bash
-docker-compose down
+docker-compose down --volumes
 ```
 
 Note: to make pgAdmin configuration persistent, create a folder `data_pgadmin`. Change its permission via


### PR DESCRIPTION
**Description**
`docker-compose down` command to remove docker containers is suggested to be changed to `docker-compose down --volumes`

