### PR TITLE
Typo while exporting the spark path

### DIFF
--- a/week_5_batch_processing/setup/linux.md
+++ b/week_5_batch_processing/setup/linux.md
@@ -74,7 +74,7 @@ rm spark-3.3.0-bin-hadoop3.tgz
 Add it to `PATH`:
 
 ```bash
-export SPARK_HOME="${HOME}/spark/spark-3.3.0-bin-hadoop3"
+export SPARK_HOME="${HOME}/spark/spark-3.3.1-bin-hadoop3"
 export PATH="${SPARK_HOME}/bin:${PATH}"
 ```
 


### PR DESCRIPTION
installed spark version is 3.3.1, however, exporting the path to the bash file is with version 3.3.0, so the exporting spark version is updated to 3.3.1 Previously

```bash
export SPARK_HOME="${HOME}/spark/spark-3.3.0-bin-hadoop3"
export PATH="${SPARK_HOME}/bin:${PATH}"
```
Updated
```bash
export SPARK_HOME="${HOME}/spark/spark-3.3.1-bin-hadoop3"
export PATH="${SPARK_HOME}/bin:${PATH}"
```