### PR TITLE
add prefect links to cohort 2023

### DIFF
--- a/cohorts/2022/week_2_data_ingestion/README.md
+++ b/cohorts/2022/week_2_data_ingestion/README.md
@@ -68,4 +68,5 @@ Did you take notes? You can share them here.
 * [Blog post by Isaac Kargar](https://kargarisaac.github.io/blog/data%20engineering/jupyter/2022/01/25/data-engineering-w2.html)
 * [Blog, notes, walkthroughs by Sandy Behrens](https://learningdataengineering540969211.wordpress.com/2022/01/30/week-2-de-zoomcamp-2-3-2-ingesting-data-to-gcp-with-airflow/)
 * [Notes from Apurva Hegde](https://github.com/apuhegde/Airflow-LocalExecutor-In-Docker#readme)
+* [Notes from Vincenzo Galante](https://binchentso.notion.site/Data-Talks-Club-Data-Engineering-Zoomcamp-8699af8e7ff94ec49e6f9bdec8eb69fd)
 * Add your notes here (above this line)

--- a/cohorts/2023/week_2_workflow_orchestration/README.md
+++ b/cohorts/2023/week_2_workflow_orchestration/README.md
@@ -99,17 +99,5 @@ Did you take notes? You can share them here.
 * [Notes from Xia He-Bleinagel](https://xiahe-bleinagel.com/2023/02/week-2-data-engineering-zoomcamp-notes-prefect/)
 * [Notes from froukje](https://github.com/froukje/de-zoomcamp/blob/main/week_2_workflow_orchestration/notes/notes_week_02.md)
 * [Notes from Balaji](https://github.com/Balajirvp/DE-Zoomcamp/blob/main/Week%202/Detailed%20Week%202%20Notes.ipynb)
-* Add your notes here (above this line)
-
-
-### 2022 notes 
-
-Most of these notes are about Airflow, but you might find them useful.
-
-* [Notes from Alvaro Navas](https://github.com/ziritrion/dataeng-zoomcamp/blob/main/notes/2_data_ingestion.md)
-* [Notes from Aaron Wright](https://github.com/ABZ-Aaron/DataEngineerZoomCamp/blob/master/week_2_data_ingestion/README.md)
-* [Notes from Abd](https://itnadigital.notion.site/Week-2-Data-Ingestion-ec2d0d36c0664bc4b8be6a554b2765fd)
-* [Blog post by Isaac Kargar](https://kargarisaac.github.io/blog/data%20engineering/jupyter/2022/01/25/data-engineering-w2.html)
-* [Blog, notes, walkthroughs by Sandy Behrens](https://learningdataengineering540969211.wordpress.com/2022/01/30/week-2-de-zoomcamp-2-3-2-ingesting-data-to-gcp-with-airflow/)
-* [Notes from Vincenzo Galante](https://binchentso.notion.site/Data-Talks-Club-Data-Engineering-Zoomcamp-8699af8e7ff94ec49e6f9bdec8eb69fd)
 * More on [Pandas vs SQL, Prefect capabilities, and testing your data](https://medium.com/@verazabeida/zoomcamp-2023-week-3-7f27bb8c483f), by Vera
+* Add your notes here (above this line)

--- a/cohorts/2023/week_2_workflow_orchestration/readme.md
+++ b/cohorts/2023/week_2_workflow_orchestration/readme.md
@@ -1,0 +1,115 @@
+## Week 2: Workflow Orchestration
+
+Python code from videos is linked [below](#code-repository).
+
+Also, if you find the commands too small to view in Kalise's videos, here's the [transcript with code for the second Prefect video](https://github.com/discdiver/prefect-zoomcamp/tree/main/flows/01_start) and the [fifth Prefect video](https://github.com/discdiver/prefect-zoomcamp/tree/main/flows/03_deployments).
+
+### Data Lake (GCS)
+
+* What is a Data Lake
+* ELT vs. ETL
+* Alternatives to components (S3/HDFS, Redshift, Snowflake etc.)
+* [Video](https://www.youtube.com/watch?v=W3Zm6rjOq70&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb)
+* [Slides](https://docs.google.com/presentation/d/1RkH-YhBz2apIjYZAxUz2Uks4Pt51-fVWVN9CcH9ckyY/edit?usp=sharing)
+
+
+### 1. Introduction to Workflow orchestration
+
+* What is orchestration?
+* Workflow orchestrators vs. other types of orchestrators
+* Core features of a workflow orchestration tool
+* Different types of workflow orchestration tools that currently exist 
+
+:movie_camera: [Video](https://www.youtube.com/watch?v=8oLs6pzHp68&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb)
+
+
+### 2. Introduction to Prefect concepts
+
+* What is Prefect?
+* Installing Prefect
+* Prefect flow
+* Creating an ETL
+* Prefect task
+* Blocks and collections
+* Orion UI
+
+:movie_camera: [Video](https://www.youtube.com/watch?v=cdtN6dhp708&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb)
+
+### 3. ETL with GCP & Prefect
+
+* Flow 1: Putting data to Google Cloud Storage 
+
+:movie_camera: [Video](https://www.youtube.com/watch?v=W-rMz_2GwqQ&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb)
+
+
+### 4. From Google Cloud Storage to Big Query
+
+* Flow 2: From GCS to BigQuery
+
+:movie_camera: [Video](https://www.youtube.com/watch?v=Cx5jt-V5sgE&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb)
+
+### 5. Parametrizing Flow & Deployments 
+
+* Parametrizing the script from your flow
+* Parameter validation with Pydantic
+* Creating a deployment locally
+* Setting up Prefect Agent
+* Running the flow
+* Notifications
+
+:movie_camera: [Video](https://www.youtube.com/watch?v=QrDxPjX10iw&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb)
+
+### 6. Schedules & Docker Storage with Infrastructure
+
+* Scheduling a deployment
+* Flow code storage
+* Running tasks in Docker
+
+:movie_camera: [Video](https://www.youtube.com/watch?v=psNSzqTsi-s&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb)
+
+### 7. Prefect Cloud and Additional Resources 
+
+
+* Using Prefect Cloud instead of local Prefect
+* Workspaces
+* Running flows on GCP
+
+:movie_camera: [Video](https://www.youtube.com/watch?v=gGC23ZK7lr8&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb)
+
+* [Prefect docs](https://docs.prefect.io/)
+* [Pefect Discourse](https://discourse.prefect.io/)
+* [Prefect Cloud](https://app.prefect.cloud/)
+* [Prefect Slack](https://prefect-community.slack.com)
+
+### Code repository
+
+[Code from videos](https://github.com/discdiver/prefect-zoomcamp) (with a few minor enhancements)
+
+### Homework 
+Homework can be found [here](./homework.md).
+
+## Community notes
+
+Did you take notes? You can share them here.
+
+* [Blog by Marcos Torregrosa (Prefect)](https://www.n4gash.com/2023/data-engineering-zoomcamp-semana-2/)
+* [Notes from Victor Padilha](https://github.com/padilha/de-zoomcamp/tree/master/week2)
+* [Notes by Alain Boisvert](https://github.com/boisalai/de-zoomcamp-2023/blob/main/week2.md)
+* [Notes by Candace Williams](https://github.com/teacherc/de_zoomcamp_candace2023/blob/main/week_2/week2_notes.md)
+* [Notes from Xia He-Bleinagel](https://xiahe-bleinagel.com/2023/02/week-2-data-engineering-zoomcamp-notes-prefect/)
+* [Notes from froukje](https://github.com/froukje/de-zoomcamp/blob/main/week_2_workflow_orchestration/notes/notes_week_02.md)
+* [Notes from Balaji](https://github.com/Balajirvp/DE-Zoomcamp/blob/main/Week%202/Detailed%20Week%202%20Notes.ipynb)
+* Add your notes here (above this line)
+
+
+### 2022 notes 
+
+Most of these notes are about Airflow, but you might find them useful.
+
+* [Notes from Alvaro Navas](https://github.com/ziritrion/dataeng-zoomcamp/blob/main/notes/2_data_ingestion.md)
+* [Notes from Aaron Wright](https://github.com/ABZ-Aaron/DataEngineerZoomCamp/blob/master/week_2_data_ingestion/README.md)
+* [Notes from Abd](https://itnadigital.notion.site/Week-2-Data-Ingestion-ec2d0d36c0664bc4b8be6a554b2765fd)
+* [Blog post by Isaac Kargar](https://kargarisaac.github.io/blog/data%20engineering/jupyter/2022/01/25/data-engineering-w2.html)
+* [Blog, notes, walkthroughs by Sandy Behrens](https://learningdataengineering540969211.wordpress.com/2022/01/30/week-2-de-zoomcamp-2-3-2-ingesting-data-to-gcp-with-airflow/)
+* [Notes from Vincenzo Galante](https://binchentso.notion.site/Data-Talks-Club-Data-Engineering-Zoomcamp-8699af8e7ff94ec49e6f9bdec8eb69fd)
+* More on [Pandas vs SQL, Prefect capabilities, and testing your data](https://medium.com/@verazabeida/zoomcamp-2023-week-3-7f27bb8c483f), by Vera

--- a/week_2_workflow_orchestration/README.md
+++ b/week_2_workflow_orchestration/README.md
@@ -3,6 +3,9 @@
 > If you're looking for Airflow videos from the 2022 edition,
 > check the [2022 cohort folder](../cohorts/2022/week_2_data_ingestion/).
 
+> If you're looking for Prefect videos from the 2023 edition,
+> check the [2023 cohort folder](../cohorts/2023/week_2_workflow_orchestration/).
+
 Python code from videos is linked [below](#code-repository).
 
 Also, if you find the commands too small to view in Kalise's videos, here's the [transcript with code for the second Prefect video](https://github.com/discdiver/prefect-zoomcamp/tree/main/flows/01_start) and the [fifth Prefect video](https://github.com/discdiver/prefect-zoomcamp/tree/main/flows/03_deployments).

--- a/week_2_workflow_orchestration/README.md
+++ b/week_2_workflow_orchestration/README.md
@@ -8,8 +8,6 @@
 
 Python code from videos is linked [below](#code-repository).
 
-Also, if you find the commands too small to view in Kalise's videos, here's the [transcript with code for the second Prefect video](https://github.com/discdiver/prefect-zoomcamp/tree/main/flows/01_start) and the [fifth Prefect video](https://github.com/discdiver/prefect-zoomcamp/tree/main/flows/03_deployments).
-
 ### Data Lake (GCS)
 
 * What is a Data Lake
@@ -24,10 +22,10 @@ Mage videos coming soon
 
 ### Code repository
 
-[Code from videos](https://github.com/discdiver/prefect-zoomcamp) (with a few minor enhancements)
+To be posted after the mage videos
 
 ### Homework 
-Homework can be found [here](../cohorts/2023/week_2_workflow_orchestration/homework.md).
+To be posted after the mage videos
 
 ## Community notes
 


### PR DESCRIPTION
Since we are shifting to mage this year, the prefect links need to be moved to the 2023 cohort. This PR has the following changes:

1. The links from module `orchestration ` were removed from the main readme in this [commit](https://github.com/DataTalksClub/data-engineering-zoomcamp/commit/c2d39fe1ef8e4a693160ce3b552efa6c528aee50). However, these still need to be added to the 2023 cohort.
2. Since rest of the modules/weeks are still the same, I have only updated the orchestration directory.
3. The reference to airflow directory is removed from this repo and that is the only deletion from when the readme was updated [here](https://github.com/DataTalksClub/data-engineering-zoomcamp/commit/c2d39fe1ef8e4a693160ce3b552efa6c528aee50). 
4. Please let me know if you want me to add the readme links with code for the rest of the modules into the 2023 cohort and I will be happy to contribute. 