### PR TITLE
Minor README changes for cohort 2024 folder

### DIFF
--- a/01-docker-terraform/README.md
+++ b/01-docker-terraform/README.md
@@ -2,7 +2,7 @@
 
 * [Video](https://www.youtube.com/watch?v=-zpVha7bw5A)
 * [Slides](https://www.slideshare.net/AlexeyGrigorev/data-engineering-zoomcamp-introduction)
-* Overview of [Architecture](https://github.com/DataTalksClub/data-engineering-zoomcamp#overview), [Technologies](https://github.com/DataTalksClub/data-engineering-zoomcamp#technologies) & [Pre-Requisites](https://github.com/DataTalksClub/data-engineering-zoomcamp#prerequisites)
+* Overview of [Architecture & Technologies](https://github.com/DataTalksClub/data-engineering-zoomcamp#overview) & [Pre-Requisites](https://github.com/DataTalksClub/data-engineering-zoomcamp#prerequisites)
 
 
 We suggest watching videos in the same order as in this document.

--- a/01-docker-terraform/README.md
+++ b/01-docker-terraform/README.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-* [Video](https://www.youtube.com/watch?v=-zpVha7bw5A)
+* [Video: "Data Engineering Zoomcamp 2023"](https://www.youtube.com/watch?v=-zpVha7bw5A)
 * [Slides](https://www.slideshare.net/AlexeyGrigorev/data-engineering-zoomcamp-introduction)
 * Overview of [Architecture & Technologies](https://github.com/DataTalksClub/data-engineering-zoomcamp#overview) & [Pre-Requisites](https://github.com/DataTalksClub/data-engineering-zoomcamp#prerequisites)
 
@@ -61,15 +61,16 @@ if you have troubles setting up the environment and following along with the vid
 
 * Introduction to GCP (Google Cloud Platform)
   * [Video](https://www.youtube.com/watch?v=18jIzE41fJ4&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb)
+  * [Companion Notes](1_terraform_gcp/2_gcp_overview.md)
 * Introduction to Terraform Concepts - Overview
   * [Video](https://youtu.be/s2bOYDCKl_M)
-  * [Companion Notes](1_terraform_gcp)
-* Terraform Basice - Simple one file Terraform Deployment
+  * [Companion Notes](1_terraform_gcp/1_terraform_overview.md)
+* Terraform Basics - Simple one file Terraform Deployment
   * [Video](https://youtu.be/Y2ux7gq3Z0o)
   * [Companion Notes](1_terraform_gcp)
 * Terraform Continued - Terraform Deployment with a Variables File
   * [Video](https://youtu.be/PBi0hHjLftk)
-  * [Companion Notes](1_terraform_gcp)    
+  * [Companion Notes](1_terraform_gcp/terraform/terraform_with_variables/)    
 * Configuring terraform and GCP SDK on Windows
   * [Instructions](1_terraform_gcp/windows.md)
 

--- a/01-docker-terraform/README.md
+++ b/01-docker-terraform/README.md
@@ -1,6 +1,7 @@
 ### Introduction
 
 * [Video: "Data Engineering Zoomcamp 2023"](https://www.youtube.com/watch?v=-zpVha7bw5A)
+* [Video: "Data Engineering Zoomcamp 2024"](https://www.youtube.com/watch?v=AtRhA-NfS24)
 * [Slides](https://www.slideshare.net/AlexeyGrigorev/data-engineering-zoomcamp-introduction)
 * Overview of [Architecture & Technologies](https://github.com/DataTalksClub/data-engineering-zoomcamp#overview) & [Pre-Requisites](https://github.com/DataTalksClub/data-engineering-zoomcamp#prerequisites)
 

--- a/cohorts/2024/README.md
+++ b/cohorts/2024/README.md
@@ -1,6 +1,6 @@
 ## Data Engineering Zoomcamp 2024 Cohort
 
-* [Pre-launch Q&A stream](https://www.youtube.com/watch?v=91b8u9GmqB4)
+* [Data Engineering Zoomcamp 2024 - Pre-Launch Q&A Stream](https://www.youtube.com/watch?v=91b8u9GmqB4)
 * Launch stream with course overview (TODO)
 * [Deadline calendar](https://docs.google.com/spreadsheets/d/e/2PACX-1vQACMLuutV5rvXg5qICuJGL-yZqIV0FBD84CxPdC5eZHf8TfzB-CJT_3Mo7U7oGVTXmSihPgQxuuoku/pubhtml)
 * [Course Google calendar](https://calendar.google.com/calendar/?cid=ZXIxcjA1M3ZlYjJpcXU0dTFmaG02MzVxMG9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
@@ -10,40 +10,48 @@
 
 [**Module 1: Introduction & Prerequisites**](01-docker-terraform/)
 
-* [Homework](01-docker-terraform/homework.md)
+* **Content**: [REPO_TOPLEVEL/01-docker-terraform/README.md](../../01-docker-terraform/README.md)
+  * Follow the order shown in the README.md linked above (ignore the folder number sequence there)
+  * The overview video linked at top of this README is from 2023, so make sure to follow 2024 instructions where applicable
+* **Homework**: [01-docker-terraform/homework.md](01-docker-terraform/homework.md)
 
 
 [**Module 2: Workflow Orchestration**](02-workflow-orchestration)
 
-* [Homework](02-workflow-orchestration/homework.md)
-* Office hours
+* **Content**: [REPO_TOPLEVEL/02-workflow-orchestration/homework.md](02-workflow-orchestration/homework.md)
+* **Office hours**: (TODO: add link here) <-- announced in course Slack "#announcements" channel & course Telegram
 
-[**Workshop 1: Data Ingestion**](workshops/dlt.md)
 
-* Workshop with dlt
-* [Homework](workshops/dlt.md)
+**Workshop 1: Data Ingestion**
+
+* [workshops/dlt.md](workshops/dlt.md)
 
 
 [**Module 3: Data Warehouse**](03-data-warehouse)
 
-* [Homework](03-data-warehouse/homework.md)
+* **Homework**: [03-data-warehouse/homework.md](03-data-warehouse/homework.md)
 
 
 [**Module 4: Analytics Engineering**](04-analytics-engineering/)
 
-* [Homework](04-analytics-engineering/homework.md)
+* **Homework**: [04-analytics-engineering/homework.md](04-analytics-engineering/homework.md)
 
 
 [**Module 5: Batch processing**](05-batch/)
 
-* [Homework](05-batch/homework.md)
+* **Homework**: [05-batch/homework.md](05-batch/homework.md)
 
 
 [**Module 6: Stream Processing**](06-streaming)
 
-* [Homework](06-streaming/homework.md)
+* **Homework**: [06-streaming/homework.md](06-streaming/homework.md)
 
 
-[**Project**](project.md)
+**Workshop 2: Stream Processing with Rising Wave**
 
-More information [here](project.md)
+* [workshops/rising-wave.md](workshops/rising-wave.md)
+
+
+**Project**
+
+* **Project**: [project.md](project.md)

--- a/cohorts/2024/README.md
+++ b/cohorts/2024/README.md
@@ -1,11 +1,11 @@
 ## Data Engineering Zoomcamp 2024 Cohort
 
 * [Data Engineering Zoomcamp 2024 - Pre-Launch Q&A Stream](https://www.youtube.com/watch?v=91b8u9GmqB4)
-* Launch stream with course overview (TODO)
+* [Data Engineering Zoomcamp 2024 (Launch)](https://www.youtube.com/watch?v=AtRhA-NfS24)
 * [Deadline calendar](https://docs.google.com/spreadsheets/d/e/2PACX-1vQACMLuutV5rvXg5qICuJGL-yZqIV0FBD84CxPdC5eZHf8TfzB-CJT_3Mo7U7oGVTXmSihPgQxuuoku/pubhtml)
 * [Course Google calendar](https://calendar.google.com/calendar/?cid=ZXIxcjA1M3ZlYjJpcXU0dTFmaG02MzVxMG9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
 * [FAQ](https://docs.google.com/document/d/19bnYs80DwuUimHM65UV3sylsCn2j1vziPOwzBwQrebw/edit?usp=sharing)
-* Course Playlist: Only 2024 Live videos & homeworks (TODO)
+* [Course Playlist: Only 2024 Live videos & homeworks](https://youtube.com/playlist?list=PL3MmuxUbc_hKihpnNQ9qtTmWYy26bPrSb&si=BYTPgbZfubh9Pmw7)
 
 
 [**Module 1: Introduction & Prerequisites**](01-docker-terraform/)

--- a/cohorts/2024/README.md
+++ b/cohorts/2024/README.md
@@ -1,7 +1,7 @@
 ## Data Engineering Zoomcamp 2024 Cohort
 
-* [Data Engineering Zoomcamp 2024 - Pre-Launch Q&A Stream](https://www.youtube.com/watch?v=91b8u9GmqB4)
-* [Data Engineering Zoomcamp 2024 (Launch)](https://www.youtube.com/watch?v=AtRhA-NfS24)
+* [Pre-Launch Q&A Stream](https://www.youtube.com/watch?v=91b8u9GmqB4)
+* [Launch Stream with Course Overview](https://www.youtube.com/watch?v=AtRhA-NfS24)
 * [Deadline calendar](https://docs.google.com/spreadsheets/d/e/2PACX-1vQACMLuutV5rvXg5qICuJGL-yZqIV0FBD84CxPdC5eZHf8TfzB-CJT_3Mo7U7oGVTXmSihPgQxuuoku/pubhtml)
 * [Course Google calendar](https://calendar.google.com/calendar/?cid=ZXIxcjA1M3ZlYjJpcXU0dTFmaG02MzVxMG9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
 * [FAQ](https://docs.google.com/document/d/19bnYs80DwuUimHM65UV3sylsCn2j1vziPOwzBwQrebw/edit?usp=sharing)


### PR DESCRIPTION
Changes:
1. Because the diagram changed in this commit: https://github.com/DataTalksClub/data-engineering-zoomcamp/commit/be68361c402995a8057ab9f70e930f7c56c18ec9 - collapsed the two now redundant links into one
2. Reformatted README's so they're more explicit than implicit (currently, pretty hard to follow)
    1. [01-docker-terraform/README.md](https://github.com/DataTalksClub/data-engineering-zoomcamp/tree/main/01-docker-terraform/README.md)
    2. [cohorts/2024/README.md](https://github.com/DataTalksClub/data-engineering-zoomcamp/tree/main/cohorts/2024/README.md)