### PR TITLE
Fix typo in JDK install instructions

### DIFF
--- a/05-batch/setup/macos.md
+++ b/05-batch/setup/macos.md
@@ -10,7 +10,7 @@ for other MacOS versions as well
 Ensure Brew and Java installed in your system:
 
 ```bash
-xcode-select –install
+xcode-select --install
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew install java
 ```


### PR DESCRIPTION
Due to the missing dash the code will yield the following error: 

`xcode-select: error: invalid argument '-install'`

since the option needs two dashes and has no shorthand flag.


**Note:**
I did not only add an extra dash, but replaced the original single dash with two dashes. This is because the original dash was a different dash from the one generated by my keyboard. (See this [issue](https://stackoverflow.com/questions/24651685/xcode-select-install-xcode-select-error-unknown-command-option-install)) So anyone who copy-pastes the instructions would have run into the issue mentioned in the post.

Now I have no idea wether this will lead to issues for other users that use a different keyboard. My hope is that the encoding depends on the OS and the issues originated from a non-mac users typing (or copy-pasting) the instructions into the readme. It could also be terminal-specific. I don't know.