### PR TITLE
module5 - update linux install instruction to download spark from archive instead

### DIFF
--- a/05-batch/setup/linux.md
+++ b/05-batch/setup/linux.md
@@ -57,8 +57,7 @@ rm openjdk-11.0.2_linux-x64_bin.tar.gz
 Download Spark. Use 3.3.2 version:
 
 ```bash
-wget https://dlcdn.apache.org/spark/spark-3.3.2/spark-3.3.2-bin-hadoop3.tgz
-
+wget https://archive.apache.org/dist/spark/spark-3.3.2/spark-3.3.2-bin-hadoop3.tgz
 ```
 
 Unpack:


### PR DESCRIPTION
Version `3.3.2` no longer available for download from https://dlcdn.apache.org/spark/ but is now available from archive location at https://archive.apache.org/dist/spark/spark-3.3.2/