### PR TITLE
Added config for partitioning and incremental loading option

### DIFF
--- a/04-analytics-engineering/taxi_rides_ny/models/core/fact_trips.sql
+++ b/04-analytics-engineering/taxi_rides_ny/models/core/fact_trips.sql
@@ -3,6 +3,11 @@
         materialized='table'
         -- materialized='incremental',
         -- unique_key='tripid'
+        partition_by={
+            "field": "pickup_datetime",
+            "data_type": "timestamp",
+            "granularity": "month"
+        }
     )
 }}
 

--- a/04-analytics-engineering/taxi_rides_ny/models/core/fact_trips.sql
+++ b/04-analytics-engineering/taxi_rides_ny/models/core/fact_trips.sql
@@ -1,6 +1,8 @@
 {{
     config(
         materialized='table'
+        -- materialized='incremental',
+        -- unique_key='tripid'
     )
 }}
 
@@ -54,3 +56,9 @@ inner join dim_zones as pickup_zone
 on trips_unioned.pickup_locationid = pickup_zone.locationid
 inner join dim_zones as dropoff_zone
 on trips_unioned.dropoff_locationid = dropoff_zone.locationid
+
+-- for fully fresh build run:
+-- dbt build --select <model.sql> --vars '{'is_test_run: false}' --full-refresh
+{% if is_incremental() %}
+WHERE pickup_datetime > (select max(pickup_datetime) from {{ this }})
+{% endif %}

--- a/04-analytics-engineering/taxi_rides_ny/models/staging/stg_green_tripdata.sql
+++ b/04-analytics-engineering/taxi_rides_ny/models/staging/stg_green_tripdata.sql
@@ -9,7 +9,9 @@ with tripdata as
   select *,
     row_number() over(partition by vendorid, lpep_pickup_datetime) as rn
   from {{ source('staging','green_tripdata') }}
-  where vendorid is not null 
+  where lpep_pickup_datetime
+    BETWEEN CAST("2019-01-01" AS TIMESTAMP) AND CAST("2020-12-31" AS TIMESTAMP)
+      AND vendorid is not null
 )
 select
     -- identifiers

--- a/04-analytics-engineering/taxi_rides_ny/models/staging/stg_yellow_tripdata.sql
+++ b/04-analytics-engineering/taxi_rides_ny/models/staging/stg_yellow_tripdata.sql
@@ -5,7 +5,9 @@ with tripdata as
   select *,
     row_number() over(partition by vendorid, tpep_pickup_datetime) as rn
   from {{ source('staging','yellow_tripdata') }}
-  where vendorid is not null 
+  where tpep_pickup_datetime
+    BETWEEN CAST("2019-01-01" AS TIMESTAMP) AND CAST("2020-12-31" AS TIMESTAMP)
+      AND vendorid is not null
 )
 select
    -- identifiers

--- a/04-analytics-engineering/taxi_rides_ny/models/staging/stg_yellow_tripdata.sql
+++ b/04-analytics-engineering/taxi_rides_ny/models/staging/stg_yellow_tripdata.sql
@@ -1,4 +1,10 @@
-{{ config(materialized='view') }}
+{{ 
+  config(
+    materialized='view'
+    -- materialized='incremental',
+    -- unique_key='tripid'
+  ) 
+}}
  
 with tripdata as 
 (
@@ -41,6 +47,12 @@ select
     {{ get_payment_type_description('payment_type') }} as payment_type_description
 from tripdata
 where rn = 1
+
+-- for fully fresh build run:
+-- dbt build --select <model.sql> --vars '{'is_test_run: false}' --full-refresh
+{% if is_incremental() %}
+AND pickup_datetime > (select max(pickup_datetime) from {{ this }})
+{% endif %}
 
 -- dbt build --select <model.sql> --vars '{'is_test_run: false}'
 {% if var('is_test_run', default=true) %}


### PR DESCRIPTION
Added partitioning option for the fact trips model since it is very likely the data consumer will query data from this table with date range, it will enhance performance and hence reduce the query cost.

There are some records from times out of the 2019-20 range, adding a filter in the staging models will guarantee cleaner data.

Incremental materialization can be very cost-effective since it'll not refresh the whole database when a job is run, it'll only load and process records that are new and update existing records.
cc: @Victoriapm 
