### PR TITLE
Fixed scala version as per issue #431

### DIFF
--- a/05-batch/setup/macos.md
+++ b/05-batch/setup/macos.md
@@ -54,7 +54,7 @@ print(f'The PySpark {spark.version} version is running...')
 1. Install Scala
 
 ```bash
-brew install scala@2.11
+brew install scala@2.13
 ```
 
 2. Install Apache Spark


### PR DESCRIPTION
Updating scala version to 2.13 as per the issue #431 where homebrew throws error for version 2.11
It seems like the Homebrew formula for Scala 2.11 is not available in the current version or has been deprecated. Scala versions are regularly updated, and older versions may not be maintained in the Homebrew formulae.