### PR TITLE
Fix spelling error: "formad" -> "format"

### DIFF
--- a/cohorts/2025/01-docker-terraform/homework.md
+++ b/cohorts/2025/01-docker-terraform/homework.md
@@ -10,7 +10,7 @@ site.
 This repository should contain the code for solving the homework. 
 
 When your solution has SQL or shell commands and not code
-(e.g. python files) file formad, include them directly in
+(e.g. python files) file format, include them directly in
 the README file of your repository.
 
 


### PR DESCRIPTION
Fix error in the spelling of the work "format".