### PR TITLE
fix homework year text to avoid confusion

### DIFF
--- a/03-data-warehouse/README.md
+++ b/03-data-warehouse/README.md
@@ -50,7 +50,7 @@
 
 # Homework
 
-* [2024 Homework](../cohorts/2025/03-data-warehouse/homework.md)
+* [2025 Homework](../cohorts/2025/03-data-warehouse/homework.md)
 
 
 # Community notes


### PR DESCRIPTION
Fix homework year text to avoid confusion. It should be 2025 instead of 2024. Please review and merge :)