### PR TITLE
Added link to latest Spark Big query connector jar file

### DIFF
--- a/05-batch/code/cloud.md
+++ b/05-batch/code/cloud.md
@@ -116,3 +116,6 @@ gcloud dataproc jobs submit pyspark \
         --output=trips_data_all.reports-2020
 ```
 
+There can be issue with latest Spark version and the Big query connector. Download links to the jar file for respective Spark versions can be found at:
+[Spark and Big query connector](https://github.com/GoogleCloudDataproc/spark-bigquery-connector)
+


### PR DESCRIPTION
The connector jar file for Spark and Big query throws error for different spark versions. The links to the Spark version and the respective jar files can be found at : https://github.com/GoogleCloudDataproc/spark-bigquery-connector. Added this link.