### PR TITLE
fix(hw4): use valid syntax for date subtraction

### DIFF
--- a/cohorts/2025/04-analytics-engineering/homework.md
+++ b/cohorts/2025/04-analytics-engineering/homework.md
@@ -61,7 +61,7 @@ Say you have to modify the following dbt_model (`fct_recent_taxi_trips.sql`) to 
 ```sql
 select *
 from {{ ref('fact_taxi_trips') }}
-where pickup_datetime >= CURRENT_DATE - INTERVAL '30 days'
+where pickup_datetime >= CURRENT_DATE - INTERVAL '30' DAY
 ```
 
 What would you change to accomplish that in a such way that command line arguments takes precedence over ENV_VARs, which takes precedence over DEFAULT value?


### PR DESCRIPTION
INTERVAL '30 days' is invalid. You may test it in BQ with this query:

    ```sql
    SELECT CURRENT_DATE - INTERVAL '30 days'  --Syntax error: Unexpected end of script at [1:43]
    ```
