### PR TITLE
Fix  instructions for homework module 4 (2025)

### DIFF
--- a/04-analytics-engineering/README.md
+++ b/04-analytics-engineering/README.md
@@ -120,6 +120,10 @@ By this stage of the course you should have already:
 
 
 
+## Homework
+* [2025 Homework](../cohorts/2025/04-analytics-engineering/homework.md)
+
+
 ## Community notes
 
 Did you take notes? You can share them here.

--- a/cohorts/2025/04-analytics-engineering/homework.md
+++ b/cohorts/2025/04-analytics-engineering/homework.md
@@ -156,7 +156,7 @@ Considering the YoY Growth in 2020, which were the yearly quarters with the best
 ### Question 6: P97/P95/P90 Taxi Monthly Fare
 
 1. Create a new model `fct_taxi_trips_monthly_fare_p95.sql`
-2. Filter out invalid entries (`fare_amount > 0`, `trip_distance > 0`, and `payment_type_description in ('Cash', 'Credit Card')`)
+2. Filter out invalid entries (`fare_amount > 0`, `trip_distance > 0`, and `payment_type_description in ('Cash', 'Credit card')`)
 3. Compute the **continous percentile** of `fare_amount` partitioning by service_type, year and and month
 
 Now, what are the values of `p97`, `p95`, `p90` for Green Taxi and Yellow Taxi, in April 2020?


### PR DESCRIPTION
Hi,

I added a link in the README of the module 4 to the homework for 2025, following the pattern of the other modules. It's a bit late for this cohort but I guess it will be useful next year.

Also, I fixed a typo in the instructions of the Question 6 of homework 4 (2025) which creates confusion.

It might be added too late but.. .who knows?