### PR TITLE
fix: update cloud instructions to run spark job

### DIFF
--- a/05-batch/code/cloud.md
+++ b/05-batch/code/cloud.md
@@ -10,8 +10,10 @@ gsutil -m cp -r pq/ gs://dtc_data_lake_de-zoomcamp-nytaxi/pq
 
 Download the jar for connecting to GCS to any location (e.g. the `lib` folder):
 
+**Note**: For other versions of GCS connector for Hadoop see [Cloud Storage connector ](https://cloud.google.com/dataproc/docs/concepts/connectors/cloud-storage#connector-setup-on-non-dataproc-clusters).
+
 ```bash
-gsutil cp gs://hadoop-lib/gcs/gcs-connector-hadoop3-2.2.5.jar
+gsutil cp gs://hadoop-lib/gcs/gcs-connector-hadoop3-2.2.5.jar ./lib/
 ```
 
 See the notebook with configuration in [09_spark_gcs.ipynb](09_spark_gcs.ipynb)
@@ -70,7 +72,7 @@ spark-submit \
 Upload the script to GCS:
 
 ```bash
-TODO
+gsutil -m cp -r 06_spark_sql.py gs://dtc_data_lake_de-zoomcamp-nytaxi/code/06_spark_sql.py
 ```
 
 Params for the job:
@@ -99,7 +101,7 @@ gcloud dataproc jobs submit pyspark \
 Upload the script to GCS:
 
 ```bash
-TODO
+gsutil -m cp -r 06_spark_sql_big_query.py gs://dtc_data_lake_de-zoomcamp-nytaxi/code/06_spark_sql_big_query.py
 ```
 
 Write results to big query ([docs](https://cloud.google.com/dataproc/docs/tutorials/bigquery-connector-spark-example#pyspark)):
@@ -119,3 +121,4 @@ gcloud dataproc jobs submit pyspark \
 There can be issue with latest Spark version and the Big query connector. Download links to the jar file for respective Spark versions can be found at:
 [Spark and Big query connector](https://github.com/GoogleCloudDataproc/spark-bigquery-connector)
 
+**Note**: Dataproc on GCE 2.1+ images pre-install Spark BigQquery connector: [DataProc Release 2.2](https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-2.2). Therefore, no need to include the jar file in the job submission.


### PR DESCRIPTION
## Description

- Update the command line to upload code files to GCS
- Update the instructions to use different Cloud Connector versions