### PR TITLE
Fix Docker compose path in 02-workflow-orchestration/README.md

### DIFF
--- a/02-workflow-orchestration/README.md
+++ b/02-workflow-orchestration/README.md
@@ -62,7 +62,7 @@ The project is organized as follows:
 We'll set up Kestra using Docker Compose containing one container for the Kestra server and another for the Postgres database:
 
 ```bash
-cd 02-workflow-orchestration/
+cd 02-workflow-orchestration/docker/combined
 docker compose up -d
 ```
 


### PR DESCRIPTION
- The previous Docker compose command pointed to the wrong path:
`cd 02-workflow-orchestration → docker compose up -d`

- However, the actual Docker setup resides in 02-workflow-orchestration/docker/combined.
- This PR updates the README to reflect the correct path, so the Docker setup works as expected.