### PR TITLE
fix: update SQL refresher link in Docker and Terraform module

### DIFF
--- a/01-docker-terraform/README.md
+++ b/01-docker-terraform/README.md
@@ -21,7 +21,7 @@ We suggest watching videos in the same order as in this document.
 [![](https://markdown-videos-api.jorgenkh.no/youtube/QEcps_iskgg)](https://youtu.be/QEcps_iskgg&list=PL3MmuxUbc_hJed7dXYoJw8DoCuVHhGEQb&index=10)
 
 * Video: https://www.youtube.com/watch?v=QEcps_iskgg
-* SQL queries: [09-sql-refresher.md](docker-sql/09-sql-refresher.md)
+* SQL queries: [09-sql-refresher.md](docker-sql/10-sql-refresher.md)
 
 
 # GCP


### PR DESCRIPTION
Updates the SQL refresher link to point to `10-sql-refresher.md`, fixing a 404 in the Docker & Terraform section.