### PR TITLE
docs:add AWS Terraform data lake README (GCP equivalent)

### DIFF
--- a/01-docker-terraform/terraform/terraform/terraform_with_variable_AWS/README.md
+++ b/01-docker-terraform/terraform/terraform/terraform_with_variable_AWS/README.md
@@ -1,0 +1,38 @@
+# AWS Terraform Data Lake (GCP Equivalent)
+
+## 📌 Overview
+
+This repository contains an **AWS-based Terraform implementation** that mirrors the **Google Cloud Platform (GCP)** infrastructure used in the Data Engineering course (e.g. GCS + BigQuery), but implemented using **AWS services**.
+
+The goal is to help learners who:
+- Are enrolled in a **GCP-focused Data Engineering course**
+- Prefer or need to work with **AWS**
+- Want to understand **cloud-agnostic data engineering concepts**
+
+This setup focuses on building a **basic data lake foundation** using:
+- **Amazon S3** (equivalent to GCS)
+- **AWS Glue Data Catalog** (equivalent to BigQuery datasets / metadata layer)
+- **Terraform** as Infrastructure as Code (IaC)
+
+---
+
+## 🏗️ Architecture Mapping (GCP → AWS)
+
+| GCP Service | AWS Equivalent | Purpose |
+|------------|---------------|---------|
+| Google Cloud Storage (GCS) | Amazon S3 | Data Lake storage |
+| Uniform Bucket Level Access | S3 Public Access Block | Secure bucket access |
+| Object Lifecycle Rules | S3 Lifecycle Configuration | Automatic data expiration |
+| BigQuery Dataset | AWS Glue Catalog Database | Metadata & query layer |
+| Terraform (GCP provider) | Terraform (AWS provider) | Infrastructure as Code |
+
+---
+
+## 📁 Project Structure
+
+```text
+.
+├── main.tf            # Core infrastructure resources
+├── variables.tf       # Input variable definitions
+├── terraform.tfvars   # Environment-specific values
+└── README.md          # Project documentation

--- a/01-docker-terraform/terraform/terraform/terraform_with_variable_AWS/main.tf
+++ b/01-docker-terraform/terraform/terraform/terraform_with_variable_AWS/main.tf
@@ -1,0 +1,58 @@
+terraform {
+    required_providers {
+        aws = {
+            source  = "hashicorp/aws"
+            version = "~> 5.0"
+        }
+    }
+}
+
+provider "aws" {
+    region = var.aws_region
+}
+
+#S3 Bucket to store data equivalent to GCS Bucket in GCP
+resource "aws_s3_bucket" "data_lake_bucket" {
+  bucket        = var.bucket_name
+  force_destroy = true
+}
+
+#Bucket verisioning
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.data_lake_bucket.id # Reference the S3 bucket created above
+
+  versioning_configuration {
+    status = "Enabled" # Enable versioning
+  }
+}
+
+# "Uniform bucket level access" ~ control prin policy/ACL; recomandat: block public access
+resource "aws_s3_bucket_public_access_block" "block_public_access" {
+  bucket = aws_s3_bucket.data_lake_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Lifecycle: delete objects older than 30 days (echivalent lifecycle_rule age=30)
+resource "aws_s3_bucket_lifecycle_configuration" "lifecycle_rules" {
+  bucket = aws_s3_bucket.data_lake_bucket.id
+
+  rule {
+    id     = "Delete_old_older_than_30_days"
+    status = "Enabled"
+
+    expiration {
+      days = 30
+    }
+    filter {
+      prefix = "" # Apply to all objects in the bucket
+    }
+  }
+}
+
+resource "aws_glue_catalog_database" "dataset" {
+  name = var.dataset_name
+}

--- a/01-docker-terraform/terraform/terraform/terraform_with_variable_AWS/terraform.tfvars
+++ b/01-docker-terraform/terraform/terraform/terraform_with_variable_AWS/terraform.tfvars
@@ -1,0 +1,2 @@
+bucket_name  = "my-unique-data-lake-bucket-12345"
+dataset_name = "ny_taxi_dataset"

--- a/01-docker-terraform/terraform/terraform/terraform_with_variable_AWS/variables.tf
+++ b/01-docker-terraform/terraform/terraform/terraform_with_variable_AWS/variables.tf
@@ -1,0 +1,19 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources in"
+  type = string
+  default = "eu-north-1"
+
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+  default     = "data-engineering-zoomcamp-1568692036"
+}
+
+
+variable "dataset_name" {
+  description = "Glue Catalog database name (logical dataset for Athena/Glue)"
+  type        = string
+  default = "ny_taxi_database"
+}


### PR DESCRIPTION
Add AWS Terraform equivalent for GCP data lake setup