### PR TITLE
Update README of 08-dockerizing-ingestion.md and 09-docker-compose.md

### DIFF
--- a/01-docker-terraform/docker-sql/08-dockerizing-ingestion.md
+++ b/01-docker-terraform/docker-sql/08-dockerizing-ingestion.md
@@ -47,12 +47,12 @@ docker build -t taxi_ingest:v001 .
 docker run -it \
   --network=pg-network \
   taxi_ingest:v001 \
-    --user=root \
-    --password=root \
-    --host=pgdatabase \
-    --port=5432 \
-    --db=ny_taxi \
-    --table=yellow_taxi_trips
+    --pg-user=root \
+    --pg-pass=root \
+    --pg-host=pgdatabase \
+    --pg-port=5432 \
+    --pg-db=ny_taxi \
+    --target-table=yellow_taxi_trips
 ```
 
 ### Important Notes

--- a/01-docker-terraform/docker-sql/09-docker-compose.md
+++ b/01-docker-terraform/docker-sql/09-docker-compose.md
@@ -95,12 +95,12 @@ docker network ls
 docker run -it \
   --network=pipeline_default \
   taxi_ingest:v001 \
-    --user=root \
-    --password=root \
-    --host=pgdatabase \
-    --port=5432 \
-    --db=ny_taxi \
-    --table=yellow_taxi_trips
+    --pg-user=root \
+    --pg-pass=root \
+    --pg-host=pgdatabase \
+    --pg-port=5432 \
+    --pg-db=ny_taxi \
+    --target-table=yellow_taxi_trips
 ```
 
 **[↑ Up](README.md)** | **[← Previous](08-dockerizing-ingestion.md)** | **[Next →](10-sql-refresher.md)**


### PR DESCRIPTION
Update the readme of 08-dockerizing-ingestion.md and 09-docker-compose.md to match the arguments in ingest_data.py script : 

<img width="1651" height="715" alt="Screenshot 2026-01-20 201414" src="https://github.com/user-attachments/assets/2a608df2-4ec4-4b0d-a297-b274e6e5be6a" />
versus
<img width="1548" height="502" alt="Screenshot 2026-01-20 201500" src="https://github.com/user-attachments/assets/90a223ec-cf4c-4932-9916-6a018396ef3a" />
 