### PR TITLE
Update psycopg[binary] installation command

### DIFF
--- a/01-docker-terraform/docker-sql/05-data-ingestion.md
+++ b/01-docker-terraform/docker-sql/05-data-ingestion.md
@@ -106,7 +106,7 @@ In the Jupyter notebook, we create code to:
 ### Install SQLAlchemy
 
 ```bash
-uv add sqlalchemy psycopg2-binary
+uv add sqlalchemy "psycopg[binary,pool]"
 ```
 
 ### Create Database Connection


### PR DESCRIPTION
While running the code :
`uv run pgcli -h localhost -p 5432 -u root -d ny_taxi`

from this section:
https://github.com/DataTalksClub/data-engineering-zoomcamp/blob/main/01-docker-terraform/docker-sql/05-data-ingestion.md

I ran into this error :

`ImportError "no pq wrapper available" when importing psycopg3
`
however when I run :
`uv add "psycopg[binary,pool]" `

That fixes the issue and is the recommended way to install psycopg according to the official docs to resolve any dependency issues. 

`https://pypi.org/project/psycopg/`

A slight modification is required for the ingest_data.py script to expressly tell SQLAlchemy to use the psycopg3 version installed and not fall back to psycopg2

will submit another pr for the ingest_data script separately.

why psycopg3? It works well and better with >= Python3.13, which the Docker image relies on.