### PR TITLE
Fix PostgreSQL connection string format

### DIFF
--- a/01-docker-terraform/docker-sql/pipeline/ingest_data.py
+++ b/01-docker-terraform/docker-sql/pipeline/ingest_data.py
@@ -46,7 +46,7 @@ def run(pg_user, pg_pass, pg_host, pg_port, pg_db, year, month, target_table, ch
     prefix = 'https://github.com/DataTalksClub/nyc-tlc-data/releases/download/yellow'
     url = f'{prefix}/yellow_tripdata_{year}-{month:02d}.csv.gz'
 
-    engine = create_engine(f'postgresql://{pg_user}:{pg_pass}@{pg_host}:{pg_port}/{pg_db}')
+    engine = create_engine(f'postgresql+psycopg://{pg_user}:{pg_pass}@{pg_host}:{pg_port}/{pg_db}')
 
     df_iter = pd.read_csv(
         url,


### PR DESCRIPTION
This fix tells SQLAlchemy to expressly use the installed psycopg version and not fall back to psycopg2 as a default.

original pr link here :

https://github.com/DataTalksClub/data-engineering-zoomcamp/pull/782