### PR TITLE
2.2.1 Update README.md

### DIFF
--- a/02-workflow-orchestration/README.md
+++ b/02-workflow-orchestration/README.md
@@ -147,7 +147,7 @@ To start building workflows in Kestra, we need to understand a number of concept
 While there are more concepts used for building powerful workflows, these are the ones we're going to use to build our data pipelines.
 
 The flow [`01_hello_world.yaml`](flows/01_hello_world.yaml) showcases all of these concepts inside of one workflow:
-- The flow has 5 tasks: 2 log tasks and a sleep task
+- The flow has 5 tasks: 3 log tasks and a sleep task
 - The flow takes an input called `name`.
 - There is a variable that takes the `name` input to generate a full welcome message.
 - An output is generated from the return task and is logged in a later log task.


### PR DESCRIPTION
The current version incorrectly states that the 01_hello_world flow contains 2 tasks, but its really 3.

```
tasks:
  - id: hello_message type: io.kestra.plugin.core.log.Log message: "{{ render(vars.welcome_message) }}"
  
  - id: generate_output
    type: io.kestra.plugin.core.debug.Return
    format: I was generated during this workflow.

  - id: sleep
    type: io.kestra.plugin.core.flow.Sleep
    duration: PT15S

  - id: log_output
    type: io.kestra.plugin.core.log.Log
    message: "This is an output: {{ outputs.generate_output.value }}"

  - id: goodbye_message type: io.kestra.plugin.core.log.Log message: "Goodbye, {{ inputs.name }}!" 
```