### PR TITLE
Fix: Use named volume for Kestra temp directory

### DIFF
--- a/02-workflow-orchestration/docker-compose.yml
+++ b/02-workflow-orchestration/docker-compose.yml
@@ -5,6 +5,8 @@ volumes:
     driver: local
   kestra_data:
     driver: local
+  kestra_tmp:
+    driver: local
 
 services:
   pgdatabase:
@@ -57,7 +59,7 @@ services:
     volumes:
       - kestra_data:/app/storage
       - /var/run/docker.sock:/var/run/docker.sock
-      - /tmp/kestra-wd:/tmp/kestra-wd
+      - kestra_tmp:/tmp/kestra-wd
     environment:
       KESTRA_CONFIGURATION: |
         datasources:


### PR DESCRIPTION
Changes:
- Replace bind mount `/tmp/kestra-wd:/tmp/kestra-wd` with named volume `kestra_tmp:/tmp/kestra-wd`
- Add `kestra_tmp` to volumes definition

Reason:
- Fixes "Permission denied" error when Kestra tries to execute Python interpreters
- Bind mounts on Windows don't preserve Linux execute permissions
- Named volumes are cross-platform compatible and avoid host filesystem permission conflicts