### PR TITLE
Clean up formatting and comments in big_query.sql

### DIFF
--- a/03-data-warehouse/big_query.sql
+++ b/03-data-warehouse/big_query.sql
@@ -1,29 +1,35 @@
 -- Query public available table
-SELECT station_id, name FROM
-    bigquery-public-data.new_york_citibike.citibike_stations
+SELECT
+    station_id,
+    name
+FROM bigquery-public-data.new_york_citibike.citibike_stations
 LIMIT 100;
 
-
--- Creating external table referring to gcs path
+-- Create an external table referencing files in GCS
 CREATE OR REPLACE EXTERNAL TABLE `taxi-rides-ny.nytaxi.external_yellow_tripdata`
 OPTIONS (
-  format = 'CSV',
-  uris = ['gs://nyc-tl-data/trip data/yellow_tripdata_2019-*.csv', 'gs://nyc-tl-data/trip data/yellow_tripdata_2020-*.csv']
+    format = 'CSV',
+    uris = [
+        'gs://nyc-tl-data/trip data/yellow_tripdata_2019-*.csv',
+        'gs://nyc-tl-data/trip data/yellow_tripdata_2020-*.csv'
+    ]
 );
 
--- Check yellow trip data
-SELECT * FROM taxi-rides-ny.nytaxi.external_yellow_tripdata limit 10;
+-- Preview yellow trip data from the external table
+SELECT *
+FROM taxi-rides-ny.nytaxi.external_yellow_tripdata
+LIMIT 10;
 
--- Create a non partitioned table from external table
+-- Create a non-partitioned table from the external table
 CREATE OR REPLACE TABLE taxi-rides-ny.nytaxi.yellow_tripdata_non_partitioned AS
-SELECT * FROM taxi-rides-ny.nytaxi.external_yellow_tripdata;
+SELECT *
+FROM taxi-rides-ny.nytaxi.external_yellow_tripdata;
 
-
--- Create a partitioned table from external table
+-- Create a partitioned table from the external table
 CREATE OR REPLACE TABLE taxi-rides-ny.nytaxi.yellow_tripdata_partitioned
-PARTITION BY
-  DATE(tpep_pickup_datetime) AS
-SELECT * FROM taxi-rides-ny.nytaxi.external_yellow_tripdata;
+PARTITION BY DATE(tpep_pickup_datetime) AS
+SELECT *
+FROM taxi-rides-ny.nytaxi.external_yellow_tripdata;
 
 -- Impact of partition
 -- Scanning 1.6GB of data
@@ -36,8 +42,11 @@ SELECT DISTINCT(VendorID)
 FROM taxi-rides-ny.nytaxi.yellow_tripdata_partitioned
 WHERE DATE(tpep_pickup_datetime) BETWEEN '2019-06-01' AND '2019-06-30';
 
--- Let's look into the partitions
-SELECT table_name, partition_id, total_rows
+-- Inspect table partitions
+SELECT
+    table_name,
+    partition_id,
+    total_rows
 FROM `nytaxi.INFORMATION_SCHEMA.PARTITIONS`
 WHERE table_name = 'yellow_tripdata_partitioned'
 ORDER BY total_rows DESC;
@@ -46,7 +55,8 @@ ORDER BY total_rows DESC;
 CREATE OR REPLACE TABLE taxi-rides-ny.nytaxi.yellow_tripdata_partitioned_clustered
 PARTITION BY DATE(tpep_pickup_datetime)
 CLUSTER BY VendorID AS
-SELECT * FROM taxi-rides-ny.nytaxi.external_yellow_tripdata;
+SELECT * 
+FROM taxi-rides-ny.nytaxi.external_yellow_tripdata;
 
 -- Query scans 1.1 GB
 SELECT count(*) as trips


### PR DESCRIPTION
This PR improves readability in big_query.sql by:

- cleaning up SQL formatting
- making comment style consistent
- standardizing keyword casing
- improving readability for beginners