### PR TITLE
Add notes about nrows=100 in data ingestion doc(nrows=100 will not trigger the DtypeWarning)

### DIFF
--- a/01-docker-terraform/docker-sql/05-data-ingestion.md
+++ b/01-docker-terraform/docker-sql/05-data-ingestion.md
@@ -50,6 +50,9 @@ df.dtypes
 # Check data shape
 df.shape
 ```
+### Note 
+- When using `nrows=100` to sample the first 100 rows, all columns have consistent data types in this subset, so **the `DtypeWarning` below will NOT appear**.
+- To reproduce the type warning shown below, remove the `nrows=100` parameter and read the full dataset.
 
 ### Handling Data Types
 


### PR DESCRIPTION

Add a note to clarify that nrows=100 will not trigger the DtypeWarning, and how to reproduce the warning