### PR TITLE
fix: remove duplicate delivery_report function in avro_example producer

### DIFF
--- a/07-streaming/extras/python/avro_example/producer.py
+++ b/07-streaming/extras/python/avro_example/producer.py
@@ -14,14 +14,6 @@ from settings import RIDE_KEY_SCHEMA_PATH, RIDE_VALUE_SCHEMA_PATH, \
     SCHEMA_REGISTRY_URL, BOOTSTRAP_SERVERS, INPUT_DATA_PATH, KAFKA_TOPIC
 
 
-def delivery_report(err, msg):
-    if err is not None:
-        print("Delivery failed for record {}: {}".format(msg.key(), err))
-        return
-    print('Record {} successfully produced to {} [{}] at offset {}'.format(
-        msg.key(), msg.topic(), msg.partition(), msg.offset()))
-
-
 class RideAvroProducer:
     def __init__(self, props: Dict):
         # Schema Registry and Serializer-Deserializer Configurations
@@ -71,7 +63,7 @@ class RideAvroProducer:
                                                                                         field=MessageField.KEY)),
                                       value=self.value_serializer(value, SerializationContext(topic=topic,
                                                                                               field=MessageField.VALUE)),
-                                      on_delivery=delivery_report)
+                                      on_delivery=self.delivery_report)
             except KeyboardInterrupt:
                 break
             except Exception as e:


### PR DESCRIPTION
## Summary

- Removes the redundant top-level `delivery_report(err, msg)` function that duplicated logic already defined as `RideAvroProducer.delivery_report` static method
- Updates `on_delivery=delivery_report` → `on_delivery=self.delivery_report` in `publish()` to use the properly encapsulated class method
- Improves code clarity and avoids ambiguity about which version of the function is active

Fixes #737

## Test plan

- [ ] Verify `producer.py` has no module-level `delivery_report` function
- [ ] Verify `publish()` calls `self.delivery_report` via `on_delivery`
- [ ] Run Avro producer end-to-end to confirm delivery callbacks still fire correctly