### PR TITLE
Optional pgAdmin Docker setup documentation

### DIFF
--- a/01-docker-terraform/docker-sql/08-dockerizing-ingestion.md
+++ b/01-docker-terraform/docker-sql/08-dockerizing-ingestion.md
@@ -61,4 +61,62 @@ docker run -it \
 * Since Postgres is running on a separate container, the host argument will have to point to the container name of Postgres (`pgdatabase`).
 * You can drop the table in pgAdmin beforehand if you want, but the script will automatically replace the pre-existing table.
 
+## (Optional) Running pgAdmin in Docker
+
+**pgAdmin** is a web-based administration tool for PostgreSQL that provides a graphical interface for browsing databases, executing SQL queries, managing schemas, and monitoring your PostgreSQL server without using the command line.
+
+If you would like a graphical interface to inspect your PostgreSQL database, you can run pgAdmin as a separate Docker container.
+
+### Start pgAdmin
+
+```bash
+docker run -it \
+  --name pgadmin \
+  --network=pg-network \
+  -e PGADMIN_DEFAULT_EMAIL=admin@admin.com \
+  -e PGADMIN_DEFAULT_PASSWORD=root \
+  -v pgadmin_data:/var/lib/pgadmin \
+  -p 8085:80 \
+  dpage/pgadmin4
+```
+
+### Explanation
+
+- `--name pgadmin`: Assigns the container the name `pgadmin`.
+- `--network=pg-network`: Connects pgAdmin to the same Docker network as the PostgreSQL container, allowing it to communicate using the container name.
+- `-e PGADMIN_DEFAULT_EMAIL=admin@admin.com`: Creates the default login email for pgAdmin.
+- `-e PGADMIN_DEFAULT_PASSWORD=root`: Sets the password for the default pgAdmin account.
+- `-v pgadmin_data:/var/lib/pgadmin`: Creates a Docker volume to persist pgAdmin settings and saved server connections.
+- `-p 8085:80`: Maps port `8085` on your host machine to port `80` inside the container.
+
+### Access pgAdmin
+
+Once the container is running, open your browser and navigate to:
+
+```
+http://localhost:8085
+```
+
+Login using:
+
+- **Email:** `admin@admin.com`
+- **Password:** `root`
+
+### Register the PostgreSQL Server
+
+After logging in:
+
+1. Right-click **Servers** → **Register** → **Server**.
+2. Under the **General** tab:
+   - **Name:** `Local PostgreSQL` (or any name you prefer)
+3. Under the **Connection** tab:
+   - **Host name/address:** `pgdatabase`
+   - **Port:** `5432`
+   - **Maintenance database:** `ny_taxi`
+   - **Username:** `root`
+   - **Password:** `root`
+4. Click **Save**.
+
+Since both containers are attached to the same Docker network (`pg-network`), pgAdmin can connect to PostgreSQL using the container name (`pgdatabase`) rather than `localhost`.
+
 **[↑ Up](README.md)** | **[← Previous](07-pgadmin.md)** | **[Next →](09-docker-compose.md)**


### PR DESCRIPTION
## Summary

This PR adds an optional section explaining how to run pgAdmin using Docker.

### Changes

- Added pgAdmin Docker run command
- Added explanation of each Docker option
- Added login credentials
- Added steps to connect pgAdmin to the PostgreSQL container
- Added a short introduction explaining what pgAdmin is

This is an optional addition intended to help beginners inspect their PostgreSQL database through a graphical interface.